### PR TITLE
Properly checking for Array type.

### DIFF
--- a/index.js
+++ b/index.js
@@ -174,7 +174,7 @@
      * @returns {Censoring}
      */
     addFilterWords: function (words) {
-      if (!words instanceof Array) {
+      if (!this.isArray(words)) {
         throw 'Invalid type supplied for addFilterWords. Expected array.';
       }
 


### PR DESCRIPTION
Fixing issue on the 'addFilterWords' method that caused an improper Array type checking.